### PR TITLE
fix(#71): add context to the build action and run after tests pass

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docker:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Build timestamp
@@ -31,5 +32,6 @@ jobs:
       - name: Build and push openhim-mediator
         uses: docker/build-push-action@v4
         with:
+          context: "{{defaultContext}}:mediator"
           push: true
           tags: medicmobile/openhim-mediator:${{ env.BUILD_TIMESTAMP }}


### PR DESCRIPTION
# Description

Add context to the build action so that it uses the mediator docker file and run this action after tests pass

medic/interoperability#71

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.