### PR TITLE
chore(#79): ignore the dist folder when running unit tests

### DIFF
--- a/mediator/jest.config.js
+++ b/mediator/jest.config.js
@@ -8,4 +8,7 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/src/**/*.ts',
   ],
+  testPathIgnorePatterns: [
+    '<rootDir>/dist/',
+  ],
 };


### PR DESCRIPTION
# Description

This fixes an issue where tests in the generated dist folder run and cause failures by ignoring that folder when running unit tests.

Closes medic/interoperability#79

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.