### PR TITLE
chore(#84): documented callback url requirements.

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -145,7 +145,7 @@ In the LTFU workflow, the `Endpoint` is crucial in creating a `ServiceRequest`. 
 - **ENDPOINT_IDENTIFIER:** An identifier for the `Endpoint` that can be used when querying the FHIR database in the future.
 - **ORG_CALLBACK_URL:** A callback URL that the mediator can use to contact the requesting system (`Organization`) in the future when a `ServiceRequest` has been fulfilled.
 
-> **NOTE** The FHIR Subscription created in the future requires `ORG_CALLBACK_URL` to accept HTTP PUT requests matching this path `${ORG_CALLBACK_URL}/:resourceType/:resourceId` and return a 200. In this workflow, the callback should expect to receive an `Encounter` resource sent back to the requesting system on `${ORG_CALLBACK_URL}/Encounter/:id`.
+> **NOTE** The FHIR `Subscription` that will be created ulteriorly requires `ORG_CALLBACK_URL` to accept HTTP `PUT` requests matching this path `${ORG_CALLBACK_URL}/:resourceType/:resourceId` and return a 200. In this workflow, the callback should expect to receive an `Encounter` resource sent back to the requesting system on `${ORG_CALLBACK_URL}/Encounter/:id`.
 
 ##### Request
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -145,6 +145,8 @@ In the LTFU workflow, the `Endpoint` is crucial in creating a `ServiceRequest`. 
 - **ENDPOINT_IDENTIFIER:** An identifier for the `Endpoint` that can be used when querying the FHIR database in the future.
 - **ORG_CALLBACK_URL:** A callback URL that the mediator can use to contact the requesting system (`Organization`) in the future when a `ServiceRequest` has been fulfilled.
 
+> **NOTE** The FHIR Subscription created in the future requires `ORG_CALLBACK_URL` to accept HTTP PUT requests matching this path `${ORG_CALLBACK_URL}/:resourceType/:resourceId` and return a 200. In this workflow, the callback should expect to receive an `Encounter` resource sent back to the requesting system on `${ORG_CALLBACK_URL}/Encounter/:id`.
+
 ##### Request
 
 


### PR DESCRIPTION
# Description

Added documentation for the FHIR callback requirement.

Closes medic/interoperability#84

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.