### PR TITLE
feat: add a 30s delay brfore deploying to avoid race condition

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,10 @@ jobs:
     outputs:
       BUILD_TIMESTAMP: ${{ steps.outputtimestamp.outputs.BUILD_TIMESTAMP }}
     steps:
+      - name: Sleep for 30 seconds
+        run: sleep 30s
+        shell: bash
+        
       - name: Build timestamp
         id: timestamp
         run: echo "BUILD_TIMESTAMP=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

Add a delay when doing the deployment to kubernetes to avoid a possible race condition where the image is not ready on docker hub.

medic/interoperability#71

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.