### PR TITLE
chore: remove Print BUILD_TIMESTAMP

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,9 +66,6 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Print BUILD_TIMESTAMP
-        run: echo $BUILD_TIMESTAMP
-
       - name: Deploy to the Kubernetes cluster
         uses: azure/k8s-deploy@v1
         with:


### PR DESCRIPTION
# Description

Remove the printing of the build timestamp since we no longer need it

medic/interoperability#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.