### PR TITLE
feat: add platform to failing containers

### DIFF
--- a/docker/docker-compose.openmrs.yml
+++ b/docker/docker-compose.openmrs.yml
@@ -3,6 +3,7 @@ version: '2.1'
 services:
   openmrs-referenceapplication-mysql:
     restart: "always"
+    platform: linux/x86_64
     image: mysql:5.6
     command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,13 +11,14 @@ services:
     
   openhim-core:
     container_name: openhim-core
+    platform: linux/x86_64
     image: jembi/openhim-core:7
     environment:
       - mongo_url=mongodb://mongo/openhim
       - mongo_atnaUrl=mongodb://mongo/openhim
     ports:
       - "8080:8080"
-      - "5000:5000"
+      - "5002:5000"
       - "5001:5001"
       - "5050:5050"
       - "5051:5051"
@@ -30,6 +31,7 @@ services:
   
   openhim-console:
     container_name: openhim-console
+    platform: linux/x86_64
     image: jembi/openhim-console:1.14.4
     ports:
         - "9000:80"


### PR DESCRIPTION
# Description

Fix failing containers

closes medic/cht-interoperability#[134

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.