### PR TITLE
fix: convert sync period to milliseconds before subtracting from the current time

### DIFF
--- a/mediator/src/controllers/openmrs.ts
+++ b/mediator/src/controllers/openmrs.ts
@@ -5,7 +5,7 @@ import { SYNC_PERIOD } from '../../config'
 export async function sync() {
   try {
     let now = Date.now();
-    let syncPeriod = parseInt(SYNC_PERIOD, 10);
+    let syncPeriod = parseInt(SYNC_PERIOD, 10) * 1000; // Convert seconds to milliseconds
     let startTime = new Date(now - syncPeriod);
 
     await syncPatients(startTime);


### PR DESCRIPTION
# Description
Fix sync period calculation

closes medic/cht-interoperability#144

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.