### PR TITLE
Get fhir resource by identifier

### DIFF
--- a/mediator/src/controllers/cht.ts
+++ b/mediator/src/controllers/cht.ts
@@ -24,7 +24,7 @@ export async function createPatient(chtPatientDoc: any) {
 
   //check if patient already exists
   const patient = await getFhirResourceByIdentifier(chtPatientDoc.doc.patient_id, 'Patient');
-  if (patient.data.total > 0){
+  if (patient?.data?.total > 0){
     return { status: 200, data: { message: `Patient with the same patient_id already exists`} };
   }
 

--- a/mediator/src/controllers/cht.ts
+++ b/mediator/src/controllers/cht.ts
@@ -1,9 +1,10 @@
 import {
+  addId,
   createFhirResource,
-  updateFhirResource,
+  getFhirResourceByIdentifier,
   getFHIRPatientResource,
   replaceReference,
-  addId
+  updateFhirResource
 } from '../utils/fhir';
 import {
   buildFhirObservationFromCht,
@@ -19,6 +20,12 @@ export async function createPatient(chtPatientDoc: any) {
   // first get patient id from source
   if (chtPatientDoc.doc.source_id){
     chtPatientDoc.doc._id = await getPatientUUIDFromSourceId(chtPatientDoc.source_id);
+  }
+
+  //check if patient already exists
+  const patient = await getFhirResourceByIdentifier(chtPatientDoc.doc.patient_id, 'Patient');
+  if (patient.data.total > 0){
+    return { status: 200, data: { message: `Patient with the same patient_id already exists`} };
   }
 
   const fhirPatient = buildFhirPatientFromCht(chtPatientDoc.doc);

--- a/mediator/src/controllers/tests/cht.spec.ts
+++ b/mediator/src/controllers/tests/cht.spec.ts
@@ -82,6 +82,21 @@ describe('CHT outgoing document controllers', () => {
         })
       );
     });
+
+    it('does not create a patient if one with the same patient_id already exists', async () => {
+      const existingPatient = PatientFactory.build();
+      jest.spyOn(fhir, 'getFhirResourceByIdentifier').mockResolvedValue({
+        data: { total: 1, entry: [ { resource: existingPatient } ] },
+        status: 200,
+      });
+
+      const data = ChtPatientFactory.build();
+
+      const res = await createPatient(data);
+
+      expect(res.status).toBe(200);
+      expect(fhir.updateFhirResource).not.toHaveBeenCalled();
+    });
   });
 
   describe('updatePatientIds', () => {

--- a/mediator/src/controllers/tests/cht.spec.ts
+++ b/mediator/src/controllers/tests/cht.spec.ts
@@ -40,6 +40,10 @@ describe('CHT outgoing document controllers', () => {
   describe('createPatient', () => {
     it('creates a FHIR Patient from CHT patient doc', async () => {
       const data = ChtPatientFactory.build();
+      jest.spyOn(fhir, 'getFhirResourceByIdentifier').mockResolvedValue({
+        data: { total: 0 },
+        status: 200,
+      });
 
       const res = await createPatient(data);
 

--- a/mediator/src/utils/fhir.ts
+++ b/mediator/src/utils/fhir.ts
@@ -248,3 +248,16 @@ export async function getFhirResource(id: string, resourceType: string) {
     return { status: error.response?.status, data: error.response?.data };
   }
 }
+
+export async function getFhirResourceByIdentifier(identifierValue: string, resourceType: string) {
+  try {
+    const res = await axios.get(
+      `${FHIR.url}/${resourceType}/?identifier=${identifierValue}`,
+      axiosOptions
+    );
+    return { status: res?.status, data: res?.data };
+  } catch (error: any) {
+    logger.error(error);
+    return { status: error.response?.status, data: error.response?.data };
+  }
+}

--- a/mediator/src/utils/openmrs_sync.ts
+++ b/mediator/src/utils/openmrs_sync.ts
@@ -136,7 +136,7 @@ async function sendPatientToFhir(patient: fhir4.Patient) {
   copyIdToNamedIdentifier(patient, patient, openMRSIdentifierType);
   addSourceMeta(patient, openMRSSource);
   const response = await updateFhirResource(patient);
-  if (response.status == 200 || response.status == 201) {
+  if (response.status == 201) {
     logger.info(`Sending Patient ${patient.id} to CHT`);
     createChtPatient(response.data);
   }

--- a/mediator/src/utils/openmrs_sync.ts
+++ b/mediator/src/utils/openmrs_sync.ts
@@ -1,14 +1,14 @@
 import {
-  getFhirResourcesSince,
-  updateFhirResource,
-  createFhirResource,
-  getIdType,
   addId,
+  addSourceMeta,
   copyIdToNamedIdentifier,
-  getFhirResource,
-  replaceReference,
+  createFhirResource,
   getFHIRPatientResource,
-  addSourceMeta
+  getFhirResourceByIdentifier,
+  getFhirResourcesSince,
+  getIdType,
+  replaceReference,
+  updateFhirResource
 } from './fhir'
 import { SYNC_INTERVAL } from '../../config'
 import { getOpenMRSResourcesSince, createOpenMRSResource } from './openmrs'
@@ -126,6 +126,12 @@ export async function compare(
   And forward to CHT if successful
 */
 async function sendPatientToFhir(patient: fhir4.Patient) {
+  // check if patient already exists
+  const openMRSPatient = await getFhirResourceByIdentifier(getIdType(patient, openMRSIdentifierType), 'Patient');
+  if (openMRSPatient.data?.total > 0) {
+    logger.error(`Patient with the same patient_id already exists`);
+    return { status: 200, data: { message: `Patient with the same ${openMRSIdentifierType} already exists`} };
+  }
   logger.info(`Sending Patient ${patient.id} to FHIR`);
   copyIdToNamedIdentifier(patient, patient, openMRSIdentifierType);
   addSourceMeta(patient, openMRSSource);


### PR DESCRIPTION
# Description

Get FHIR resource by identifier and use that to prevent duplicates

medic/interoperability#141

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.