### PR TITLE
feat: make encounter requests idempotent

### DIFF
--- a/mediator/src/utils/fhir.ts
+++ b/mediator/src/utils/fhir.ts
@@ -248,3 +248,16 @@ export async function getFhirResource(id: string, resourceType: string) {
     return { status: error.response?.status, data: error.response?.data };
   }
 }
+
+export async function getFhirResourceByIdentifier(identifierValue: string, resourceType: string) {
+  try {
+    const res = await axios.get(
+      `${FHIR.url}/${resourceType}/?identifier=${identifierValue}`,
+      axiosOptions
+    );
+    return { status: res?.status, data: res?.data };
+  } catch (error: any) {
+    logger.error(error);
+    return { status: error.response?.status, data: error.response?.data };
+  }
+}

--- a/mediator/src/utils/openmrs_sync.ts
+++ b/mediator/src/utils/openmrs_sync.ts
@@ -278,60 +278,89 @@ export async function sendEncounterToFhir(
   encounter: fhir4.Encounter,
   references: fhir4.Resource[]
 ) {
-  if (encounter.meta?.source == chtSource) {
-    logger.error(`Not re-sending encounter from cht ${encounter.id}`);
-    return
-  }
-
-  if (!encounter.period?.end) {
-    logger.error(`Not sending encounter which is incomplete ${encounter.id}`);
-    return 
-  }
-
-  const identifier = getIdType(encounter, openMRSIdentifierType);
-  const existingEncounter = await getFhirResourceByIdentifier(identifier, 'Encounter');
-  if (existingEncounter?.data?.total > 0) {
-    logger.error(`Not re-sending encounter from openMRS ${encounter.id}`);
-    return
+  if (isEncounterFromCht(encounter) || isEncounterIncomplete(encounter) || await isEncounterAlreadySent(encounter)) {
+    return;
   }
 
   logger.info(`Sending Encounter ${encounter.id} to FHIR`);
 
   const observations = getObservations(encounter, references);
-
   const patient = getPatient(encounter, references);
-  if (!patient?.id) {
-    logger.error(`Patient ${encounter.subject!.reference} not found for ${encounter.id}`);
-    return
+
+  if (!await isPatientValid(patient, encounter)) {
+    return;
   }
 
-  // get patient from FHIR to resolve reference
+  prepareEncounterForFhir(encounter, patient);
+
+  if (!await saveEncounterToFhir(encounter)) {
+    return;
+  }
+
+  observations.forEach(o => sendObservationToFhir(o, patient));
+  sendEncounterToCht(encounter, patient, observations);
+}
+
+function isEncounterFromCht(encounter: fhir4.Encounter): boolean {
+  if (encounter.meta?.source == chtSource) {
+    logger.error(`Not re-sending encounter from cht ${encounter.id}`);
+    return true;
+  }
+  return false;
+}
+
+function isEncounterIncomplete(encounter: fhir4.Encounter): boolean {
+  if (!encounter.period?.end) {
+    logger.error(`Not sending encounter which is incomplete ${encounter.id}`);
+    return true;
+  }
+  return false;
+}
+
+async function isEncounterAlreadySent(encounter: fhir4.Encounter): Promise<boolean> {
+  const identifier = getIdType(encounter, openMRSIdentifierType);
+  const existingEncounter = await getFhirResourceByIdentifier(identifier, 'Encounter');
+  if (existingEncounter?.data?.total > 0) {
+    logger.error(`Not re-sending encounter from openMRS ${encounter.id}`);
+    return true;
+  }
+  return false;
+}
+
+async function isPatientValid(patient: fhir4.Patient | undefined, encounter: fhir4.Encounter): Promise<boolean> {
+  if (!patient?.id) {
+    logger.error(`Patient ${encounter.subject!.reference} not found for ${encounter.id}`);
+    return false;
+  }
+
   const patientResponse = await getFHIRPatientResource(patient.id);
   if (patientResponse.status != 200) {
     logger.error(`Error getting Patient ${patient.id}: ${patientResponse.status}`);
-    return
+    return false;
   }
 
-  const existingPatient = patientResponse.data?.entry[0].resource;
+  return true;
+}
+
+function prepareEncounterForFhir(encounter: fhir4.Encounter, patient: fhir4.Patient) {
+  const existingPatient = patient;
   copyIdToNamedIdentifier(encounter, encounter, openMRSIdentifierType);
   addSourceMeta(encounter, openMRSSource);
 
   logger.info(`Replacing ${encounter.subject!.reference} with ${patient.id} for ${encounter.id}`);
   replaceReference(encounter, 'subject', existingPatient);
 
-  // remove unused references
   delete encounter.participant;
   delete encounter.location;
+}
 
+async function saveEncounterToFhir(encounter: fhir4.Encounter): Promise<boolean> {
   const response = await updateFhirResource(encounter);
   if (response.status != 201) {
     logger.error(`Error saving encounter to fhir ${encounter.id}: ${response.status}`);
-    return
+    return false;
   }
-
-  observations.forEach(o => sendObservationToFhir(o, existingPatient));
-
-  sendEncounterToCht(encounter, existingPatient, observations);
+  return true;
 }
 
 /*

--- a/mediator/src/utils/tests/openmrs_sync.spec.ts
+++ b/mediator/src/utils/tests/openmrs_sync.spec.ts
@@ -257,5 +257,99 @@ describe('OpenMRS Sync', () => {
 
       expect(openmrs.createOpenMRSResource).toHaveBeenCalledWith(fhirObservation);
     });
+    it('does not send incoming Encounters to FHIR and CHT if OpenMRS identifier exists', async () => {
+      const lastUpdated = new Date();
+      lastUpdated.setMinutes(lastUpdated.getMinutes() - 30);
+
+      const openMRSPatient = PatientFactory.build();
+      openMRSPatient.meta = { lastUpdated: lastUpdated };
+      const openMRSEncounter = EncounterFactory.build();
+      openMRSEncounter.meta = { lastUpdated: lastUpdated };
+      openMRSEncounter.subject = {
+        reference: `Patient/${openMRSPatient.id}`
+      };
+      const openMRSObservation = ObservationFactory.build();
+      openMRSObservation.encounter = { reference: 'Encounter/' + openMRSEncounter.id }
+
+      jest.spyOn(fhir, 'getFhirResourcesSince').mockResolvedValueOnce({
+        data: [],
+        status: 200,
+      });
+
+      jest.spyOn(openmrs, 'getOpenMRSResourcesSince').mockResolvedValueOnce({
+        data: [openMRSEncounter, openMRSPatient, openMRSObservation],
+        status: 200,
+      });
+
+      jest.spyOn(fhir, 'getFHIRPatientResource').mockResolvedValueOnce({
+        data: { entry: [{ resource: openMRSPatient }] },
+        status: 200,
+      });
+
+      jest.spyOn(fhir, 'getFhirResourceByIdentifier').mockResolvedValue({
+        data: { total: 1, entry: [ { resource: openMRSPatient } ] },
+        status: 200,
+      });
+
+      jest.spyOn(fhir, 'updateFhirResource').mockResolvedValue({
+        data: [],
+        status: 201,
+      });
+
+      jest.spyOn(fhir, 'createFhirResource')
+
+      const startTime = new Date();
+      startTime.setHours(startTime.getHours() - 1);
+      const comparison = await syncEncounters(startTime);
+
+      expect(fhir.getFhirResourcesSince).toHaveBeenCalled();
+      expect(openmrs.getOpenMRSResourcesSince).toHaveBeenCalled();
+
+      expect(fhir.updateFhirResource).not.toHaveBeenCalled();
+    });
+
+    it('does not send outgoing Encounters to OpenMRS if identifier exists in FHIR', async () => {
+      const lastUpdated = new Date();
+      lastUpdated.setMinutes(lastUpdated.getMinutes() - 30);
+
+      const fhirEncounter = EncounterFactory.build();
+      fhirEncounter.meta = { lastUpdated: lastUpdated };
+      const fhirObservation = ObservationFactory.build();
+      fhirObservation.encounter = { reference: 'Encounter/' + fhirEncounter.id }
+      const chtDocId = {
+        system: "cht",
+        type: chtDocumentIdentifierType,
+        value: getIdType(fhirEncounter, chtDocumentIdentifierType)
+      }
+
+      jest.spyOn(fhir, 'getFhirResourcesSince').mockResolvedValueOnce({
+        data: [fhirEncounter, fhirObservation],
+        status: 200,
+      });
+
+      jest.spyOn(openmrs, 'getOpenMRSResourcesSince').mockResolvedValueOnce({
+        data: [],
+        status: 200,
+      });
+
+      jest.spyOn(fhir, 'getFhirResourceByIdentifier').mockResolvedValue({
+        data: { total: 1, entry: [ { resource: fhirEncounter } ] },
+        status: 200,
+      });
+
+      jest.spyOn(openmrs, 'createOpenMRSResource').mockResolvedValue({
+        data: [],
+        status: 201,
+      });
+
+      const startTime = new Date();
+      startTime.setHours(startTime.getHours() - 1);
+      const comparison = await syncEncounters(startTime);
+
+      expect(fhir.getFhirResourcesSince).toHaveBeenCalled();
+      expect(openmrs.getOpenMRSResourcesSince).toHaveBeenCalled();
+
+      expect(openmrs.createOpenMRSResource).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Description

Make Encounter resource requests idempotent by making use of the system identifier

closes https://github.com/medic/config-gandaki/issues/25

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.